### PR TITLE
allowed to change columns when perform search

### DIFF
--- a/src/Handler/ColumnsHandler.php
+++ b/src/Handler/ColumnsHandler.php
@@ -44,7 +44,7 @@ class ColumnsHandler
 
         $dt_cols = $this->getColumns();
 
-        $db_cols = $db_cols_initial = $db_cols_mid = $db_cols_final = $db_cols_final_clean = $formatter = [];
+        $db_cols = $db_cols_initial = $db_cols_mid = $db_cols_final = $db_cols_final_clean = $db_cols_for_search = $formatter = [];
 
         foreach ($dt_cols as $key => $dt_col) {
             if (isset($dt_col['db'])) {
@@ -71,11 +71,18 @@ class ColumnsHandler
                 }
 
                 $db_cols_final_clean[$key] = $db_cols_final[$key];
+
+                if (isset($dt_col['db_for_search'])) {
+                    $db_cols_for_search[$key] = $dt_col['db_for_search'];
+                } else {
+                    $db_cols_for_search[$key] = $db_cols_initial[$key];
+                }
             } else if (isset($dt_col['db_fake'])) {
                 $db_cols_initial[$key] = $dt_col['db_fake'] . $this->db_fake_identifier;
                 $db_cols_mid[$key] = $dt_col['db_fake'] . $this->db_fake_identifier;
                 $db_cols_final[$key] = $dt_col['db_fake'] . $this->db_fake_identifier;
                 $db_cols_final_clean[$key] = $dt_col['db_fake'];
+                $db_cols_for_search[$key] = null;
             }
 
             if (isset($dt_col['formatter'])) $formatter[$key] = $dt_col['formatter'];
@@ -92,6 +99,7 @@ class ColumnsHandler
             'db_cols_mid' => $db_cols_mid,
             'db_cols_final' => $db_cols_final,
             'db_cols_final_clean' => $db_cols_final_clean,
+            'db_cols_for_search' => $db_cols_for_search,
             'formatter' => $formatter,
         ];
 
@@ -110,7 +118,11 @@ class ColumnsHandler
 
     public function isDbFake($db_col): bool
     {
-        return strpos($db_col, $this->db_fake_identifier) !== false;
+        if (is_string($db_col)) {
+            return strpos($db_col, $this->db_fake_identifier) !== false;
+        }
+
+        return false;
     }
 
     public function getDtLabel(array $dt_col, string $db_col): string

--- a/src/Handler/QueryHandler.php
+++ b/src/Handler/QueryHandler.php
@@ -213,13 +213,13 @@ class QueryHandler
         if (!empty($search_value)) {
             $arranged_cols_details = $this->handler->columns()->getArrangedColsDetails();
             $dt_cols = $arranged_cols_details['dt_cols'];
-            $db_cols_initial = $arranged_cols_details['db_cols_initial'];
+            $db_cols_for_search = $arranged_cols_details['db_cols_for_search'];
 
-            $query->where(function ($the_query) use ($dt_cols, $db_cols_initial, $search_value) {
+            $query->where(function ($the_query) use ($dt_cols, $db_cols_for_search, $search_value) {
                 $count = 0;
-                foreach ($db_cols_initial as $index => $e_col) {
+                foreach ($db_cols_for_search as $index => $e_col) {
+                    if (empty($e_col)) continue;
                     if (! ($dt_cols[$index]['searchable'] ?? true)) continue;
-                    if ($this->handler->columns()->isDbFake($e_col)) continue;
 
                     if ($count == 0) $the_query->where($e_col, 'LIKE', "%".$search_value."%");
                     else $the_query->orWhere($e_col, 'LIKE', "%".$search_value."%");


### PR DESCRIPTION
as we can see example below, when perform search, ssp will take `syarikats.nama_syarikat` as column for search instead of `DB::raw("GROUP_CONCAT(syarikats.nama_syarikat SEPARATOR ', ')`..



```
protected function columns(): array
    {
        return [
            'profil_usahawans.no_hp AS no_hp_usahawan',
            'users.email AS email_usahawan',
            [
                'db' => DB::raw("GROUP_CONCAT(`syarikats`.`nama_syarikat` SEPARATOR ', ') AS `nama_syarikats`"),
                'db_for_search' => 'syarikats.nama_syarikat',
            ],
        ];
    }
```